### PR TITLE
Add persistent SQLite data layer with migration bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@
 *.log
 *.sql
 *.sqlite
+!src/db/migrations/*.sql
+src/db/school.db
 
 # OS generated files #
 ######################

--- a/src/README.md
+++ b/src/README.md
@@ -1,24 +1,28 @@
 # Mergington High School Activities API
 
-A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
+A FastAPI application that allows students to view and sign up for extracurricular activities.
+Data is persisted in a local SQLite database.
 
 ## Features
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister from activities
+- Data persists across app restarts
+- SQL migration bootstrap on startup
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r requirements.txt
    ```
 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn src.app:app --reload
    ```
 
 3. Open your browser and go to:
@@ -27,24 +31,34 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 ## API Endpoints
 
-| Method | Endpoint                                                          | Description                                                         |
-| ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| Method | Endpoint                                                            | Description                                                         |
+| ------ | ------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| GET    | `/activities`                                                       | Get all activities with details and current participant list        |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu`  | Sign up a student for an activity                                   |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity                               |
+
+## Database and Migrations
+
+- Database engine: SQLite (`src/db/school.db`)
+- Migration strategy: SQL-file migrations applied automatically at startup
+- Migration files location: `src/db/migrations`
+
+Current schema includes these tables:
+
+- `users`
+- `activities`
+- `activity_participants`
+- `clubs` (future-ready)
+- `club_memberships` (future-ready)
+- `schema_migrations`
+
+When the app starts, it will:
+
+1. Create the database file if it does not exist.
+2. Apply all unapplied `.sql` migrations from `src/db/migrations`.
+3. Seed default activities and participants only if activities are empty.
 
 ## Data Model
 
-The application uses a simple data model with meaningful identifiers:
-
-1. **Activities** - Uses activity name as identifier:
-
-   - Description
-   - Schedule
-   - Maximum number of participants allowed
-   - List of student emails who are signed up
-
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
-
-All data is stored in memory, which means data will be reset when the server restarts.
+The API still exposes activities keyed by activity name and participant email list,
+while internally storing normalized records in relational tables.

--- a/src/activity_repository.py
+++ b/src/activity_repository.py
@@ -1,0 +1,96 @@
+"""Repository layer for activity reads and enrollment writes."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+class ActivityRepository:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def list_activities(self) -> dict[str, dict]:
+        rows = self.conn.execute(
+            """
+            SELECT
+                a.name,
+                a.description,
+                a.schedule,
+                a.max_participants,
+                u.email AS participant_email
+            FROM activities a
+            LEFT JOIN activity_participants ap ON ap.activity_id = a.id
+            LEFT JOIN users u ON u.id = ap.user_id
+            ORDER BY a.name, u.email
+            """
+        ).fetchall()
+
+        result: dict[str, dict] = {}
+        for row in rows:
+            activity_name = row["name"]
+            if activity_name not in result:
+                result[activity_name] = {
+                    "description": row["description"],
+                    "schedule": row["schedule"],
+                    "max_participants": row["max_participants"],
+                    "participants": [],
+                }
+
+            if row["participant_email"]:
+                result[activity_name]["participants"].append(row["participant_email"])
+
+        return result
+
+    def signup(self, activity_name: str, email: str) -> None:
+        activity = self.conn.execute(
+            "SELECT id FROM activities WHERE name = ?", (activity_name,)
+        ).fetchone()
+        if not activity:
+            raise ValueError("activity_not_found")
+
+        user = self.conn.execute("SELECT id FROM users WHERE email = ?", (email,)).fetchone()
+        if not user:
+            self.conn.execute(
+                "INSERT INTO users(email, display_name) VALUES (?, ?)",
+                (email, email.split("@")[0].replace(".", " ").title()),
+            )
+            user = self.conn.execute(
+                "SELECT id FROM users WHERE email = ?", (email,)
+            ).fetchone()
+
+        existing_signup = self.conn.execute(
+            """
+            SELECT 1
+            FROM activity_participants
+            WHERE activity_id = ? AND user_id = ?
+            """,
+            (activity["id"], user["id"]),
+        ).fetchone()
+        if existing_signup:
+            raise ValueError("already_signed_up")
+
+        self.conn.execute(
+            "INSERT INTO activity_participants(activity_id, user_id) VALUES (?, ?)",
+            (activity["id"], user["id"]),
+        )
+
+    def unregister(self, activity_name: str, email: str) -> None:
+        activity = self.conn.execute(
+            "SELECT id FROM activities WHERE name = ?", (activity_name,)
+        ).fetchone()
+        if not activity:
+            raise ValueError("activity_not_found")
+
+        user = self.conn.execute("SELECT id FROM users WHERE email = ?", (email,)).fetchone()
+        if not user:
+            raise ValueError("not_signed_up")
+
+        deleted = self.conn.execute(
+            """
+            DELETE FROM activity_participants
+            WHERE activity_id = ? AND user_id = ?
+            """,
+            (activity["id"], user["id"]),
+        )
+        if deleted.rowcount == 0:
+            raise ValueError("not_signed_up")

--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,9 @@ from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
 
+from src.activity_repository import ActivityRepository
+from src.database import get_connection, init_database
+
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
@@ -19,63 +22,7 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+init_database()
 
 
 @app.get("/")
@@ -85,48 +32,48 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    with get_connection() as conn:
+        repository = ActivityRepository(conn)
+        return repository.list_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as conn:
+        repository = ActivityRepository(conn)
+        try:
+            repository.signup(activity_name, email)
+            conn.commit()
+        except ValueError as exc:
+            if str(exc) == "activity_not_found":
+                raise HTTPException(status_code=404, detail="Activity not found") from exc
+            if str(exc) == "already_signed_up":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Student is already signed up"
+                ) from exc
+            raise
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as conn:
+        repository = ActivityRepository(conn)
+        try:
+            repository.unregister(activity_name, email)
+            conn.commit()
+        except ValueError as exc:
+            if str(exc) == "activity_not_found":
+                raise HTTPException(status_code=404, detail="Activity not found") from exc
+            if str(exc) == "not_signed_up":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Student is not signed up for this activity"
+                ) from exc
+            raise
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,152 @@
+"""Database setup, migration bootstrap, and seed data utilities."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent
+DATA_DIR = BASE_DIR / "db"
+DB_PATH = DATA_DIR / "school.db"
+MIGRATIONS_DIR = DATA_DIR / "migrations"
+
+INITIAL_ACTIVITIES = {
+    "Chess Club": {
+        "description": "Learn strategies and compete in chess tournaments",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+    },
+    "Programming Class": {
+        "description": "Learn programming fundamentals and build software projects",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+    },
+    "Gym Class": {
+        "description": "Physical education and sports activities",
+        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+        "max_participants": 30,
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+    },
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+    },
+    "Basketball Team": {
+        "description": "Practice and play basketball with the school team",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+    },
+    "Art Club": {
+        "description": "Explore your creativity through painting and drawing",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+    },
+    "Drama Club": {
+        "description": "Act, direct, and produce plays and performances",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+    },
+    "Math Club": {
+        "description": "Solve challenging problems and participate in math competitions",
+        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
+}
+
+
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_database() -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        for migration_path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+            version = migration_path.name
+            applied = conn.execute(
+                "SELECT 1 FROM schema_migrations WHERE version = ?", (version,)
+            ).fetchone()
+            if applied:
+                continue
+
+            migration_sql = migration_path.read_text(encoding="utf-8")
+            conn.executescript(migration_sql)
+            conn.execute(
+                "INSERT INTO schema_migrations(version) VALUES (?)",
+                (version,),
+            )
+
+        seed_if_empty(conn)
+        conn.commit()
+
+
+def seed_if_empty(conn: sqlite3.Connection) -> None:
+    existing_activities = conn.execute("SELECT COUNT(*) AS count FROM activities").fetchone()
+    if existing_activities and existing_activities["count"] > 0:
+        return
+
+    for name, activity in INITIAL_ACTIVITIES.items():
+        conn.execute(
+            """
+            INSERT INTO activities(name, description, schedule, max_participants)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                name,
+                activity["description"],
+                activity["schedule"],
+                activity["max_participants"],
+            ),
+        )
+
+        activity_id = conn.execute(
+            "SELECT id FROM activities WHERE name = ?", (name,)
+        ).fetchone()["id"]
+
+        for email in activity["participants"]:
+            conn.execute(
+                """
+                INSERT INTO users(email, display_name)
+                VALUES (?, ?)
+                ON CONFLICT(email) DO NOTHING
+                """,
+                (email, email.split("@")[0].replace(".", " ").title()),
+            )
+            user_id = conn.execute(
+                "SELECT id FROM users WHERE email = ?", (email,)
+            ).fetchone()["id"]
+            conn.execute(
+                """
+                INSERT INTO activity_participants(activity_id, user_id)
+                VALUES (?, ?)
+                ON CONFLICT(activity_id, user_id) DO NOTHING
+                """,
+                (activity_id, user_id),
+            )

--- a/src/db/migrations/001_initial_schema.sql
+++ b/src/db/migrations/001_initial_schema.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    display_name TEXT,
+    role TEXT NOT NULL DEFAULT 'student',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS activities (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL,
+    schedule TEXT NOT NULL,
+    max_participants INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS activity_participants (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    activity_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    joined_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(activity_id, user_id),
+    FOREIGN KEY (activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS clubs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    intro TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS club_memberships (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    club_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    role TEXT NOT NULL DEFAULT 'member',
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(club_id, user_id),
+    FOREIGN KEY (club_id) REFERENCES clubs(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
Implements the first priority issue by moving activity data from in-memory storage to persistent SQLite-backed storage and adding migration bootstrap support.

## Changes
- Add database bootstrap and migration runner in `src/database.py`
- Add initial migration `src/db/migrations/001_initial_schema.sql`
- Add repository layer for activity queries and enrollment operations in `src/activity_repository.py`
- Refactor API endpoints in `src/app.py` to use the repository + database connection
- Update `src/README.md` with DB and migration setup details, plus unregister endpoint docs
- Update `.gitignore` to keep local DB file ignored and migration SQL tracked

## Validation
- App starts successfully and auto-applies migrations
- `GET /activities` returns expected structure
- Signup and unregister endpoints work with persisted data
- Data persists across app restarts

Closes #8